### PR TITLE
Implemented stub for startup config errors

### DIFF
--- a/asa_parser/src/asa_parse.py
+++ b/asa_parser/src/asa_parse.py
@@ -34,3 +34,7 @@ class AsaParser(ShowTech):
                 fh_list.append(fh)
                 group_found = False
         return json.dumps(fh_list)
+
+    def startup_config_errors(self):
+        """Parser for show startup-config errors"""
+        return json.dumps({'text': self.get_show_section('startup-config errors')})

--- a/asa_parser/tests/test_parser.py
+++ b/asa_parser/tests/test_parser.py
@@ -56,3 +56,6 @@ class ParserTest(unittest.TestCase):
         # Check to make sure the parser returns the expected value
         asa = ap.AsaParser(os.path.join(self.txt_path, 'show_failover_history.txt'))
         self.assertEqual(expected, asa.failover_history())
+
+    def test_startup_config_errors(self):
+        self.assertEqual(True, True)

--- a/demo.py
+++ b/demo.py
@@ -24,6 +24,9 @@ def run_demo():
     print(df['Reason'].value_counts())
     print('Demo Message')
 
+    # startup-config errors
+    print(primary_asa.startup_config_errors())
+
 
 if __name__ == "__main__":
     run_demo()


### PR DESCRIPTION
https://github.com/NCATComp410/comp410_fall_2020/issues/24

```
test_parser.py::ParserTest::test_show_clock PASSED                       [ 33%]
test_parser.py::ParserTest::test_show_failover_history PASSED            [ 66%]
test_parser.py::ParserTest::test_startup_config_errors PASSED            [100%]

============================== 3 passed in 0.45s ==============================

Process finished with exit code 0
```