### PR TITLE
Added tests for show_startup_config_errors

### DIFF
--- a/asa_parser/tests/show_startup_config_errors.txt
+++ b/asa_parser/tests/show_startup_config_errors.txt
@@ -1,0 +1,46 @@
+------------------ show startup-config errors ------------------
+
+Reading from flash...
+!! MIO module heartbeat failure detected
+ failover can not be enabled.
+*** Output from config line 153, "failover"
+INFO: Admin context is required to get the interfaces
+*** Output from config line 164, "arp timeout 14400"
+INFO: Admin context is required to get the interfaces
+*** Output from config line 165, "no arp permit-nonconnect..."
+INFO: Admin context is required to get the interfaces
+*** Output from config line 166, "arp rate-limit 32768"
+Creating context 'admin'... Done. (1)
+*** Output from config line 181, "admin-context admin"
+*** Output from config line 476, context 'admin', " protocol esp encryption..."
+*** Output from config line 477, context 'admin', " protocol esp integrity ..."
+WARNING: No 'anyconnect image' commands have been issued in the admin context. At least one AnyConnect image must be configured in the admin context to enable this feature in a context
+*** Output from config line 573, context 'admin', " anyconnect enable"
+*** Output from config line 184, "  config-url disk0:/admi..."
+Creating context 'inside1'... Done. (2)
+*** Output from config line 187, "context inside1"
+Creating context 'inside2'... Done. (3)
+*** Output from config line 192, "context inside2"
+Creating context 'inside-6-7-9-10'... Done. (4)
+*** Output from config line 199, "context inside-6-7-9-10"
+Creating context 'inside2-6'... Done. (5)
+*** Output from config line 204, "context inside2-6"
+
+WARNING: Could not fetch the URL disk0:/inside-2-6
+ERROR: Inspect configuration of this type exists, first remove
+that configuration and then add the new configuration
+*** Output from config line 207, "  config-url disk0:/insi..."
+Creating context 'inside11'... Done. (6)
+*** Output from config line 211, "context inside11"
+Creating context 'inside13'... Done. (7)
+*** Output from config line 217, "context inside13"
+Creating context 'inside14'... Done. (8)
+*** Output from config line 223, "context inside14"
+Creating context 'inside4'... Done. (9)
+*** Output from config line 229, "context inside4"
+Creating context 'inside2-1'... Done. (10)
+*** Output from config line 236, "context inside2-1"
+Creating context 'inside2-2'... Done. (11)
+*** Output from config line 241, "context inside2-2"
+Creating context 'inside2-4'... Done. (12)
+*** Output from config line 248, "context inside2-4"

--- a/asa_parser/tests/test_parser.py
+++ b/asa_parser/tests/test_parser.py
@@ -58,7 +58,22 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(expected, asa.failover_history())
 
     def test_startup_config_errors(self):
-        self.assertEqual(True, True)
+        # create a new text file in the tests directory called show_startup_config_errors.txt
+        # this file will contain only the "show startup-config errors" section from the main
+        # showtech_primary.txt file.  This is done to separate testing functionality from the
+        # main production functionality.
+        asa = ap.AsaParser(os.path.join(self.txt_path, 'show_startup_config_errors.txt'))
+
+        # execute the parser and get the result
+        # for now this will simply be a list of all the text in the section
+        # the return is in JSON format
+        result = asa.startup_config_errors()
+
+        # make sure the text section appears in the JSON return
+        self.assertIn('"text":', result)
+
+        # check to make sure the first line of the show section is present in the JSON return
+        self.assertIn('["Reading from flash..."', result)
 
     def test_tech_support_license(self):
         self.assertEqual(True, True)


### PR DESCRIPTION
https://github.com/NCATComp410/comp410_fall_2020/issues/61
```
pytest --cov=asa_parser

---------- coverage: platform darwin, python 3.8.5-final-0 -----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
asa_parser/__init__.py                2      0   100%
asa_parser/src/asa_parse.py          44     11    75%
asa_parser/src/shtech_parse.py       27      1    96%
asa_parser/tests/__init__.py          0      0   100%
asa_parser/tests/test_parser.py      34      0   100%
-----------------------------------------------------
TOTAL                               107     12    89%
```