### PR TITLE
add parser for show memory region

### DIFF
--- a/asa_parser/src/asa_parse.py
+++ b/asa_parser/src/asa_parse.py
@@ -108,7 +108,22 @@ class AsaParser(ShowTech):
 
     def show_memory_region(self):
         """Parser for show_memory region"""
-        return json.dumps({'text': self.get_show_section('memory region')})
+        memory_region = []
+        info = ''
+
+        for line in self.get_show_section('show_memory_region'):
+            if ' ASLR ' in line:
+                info = line
+                memory_region.append(info)
+            else:
+                data = line.split()
+                mem = {'Address': data[0],
+                       'Perm': data[1],
+                       'Offset': data[3],
+                       'Dev': data[4],
+                       'Inode': data[5]}
+                memory_region.append(mem)
+        return json.dumps(memory_region)
 
     def show_cpu_detailed(self):
         """Parser for show cpu detailed"""

--- a/asa_parser/src/asa_parse.py
+++ b/asa_parser/src/asa_parse.py
@@ -119,9 +119,9 @@ class AsaParser(ShowTech):
                 data = line.split()
                 mem = {'Address': data[0],
                        'Perm': data[1],
-                       'Offset': data[3],
-                       'Dev': data[4],
-                       'Inode': data[5]}
+                       'Offset': data[2],
+                       'Dev': data[3],
+                       'Inode': data[4]}
                 memory_region.append(mem)
         return json.dumps(memory_region)
 

--- a/asa_parser/src/asa_parse.py
+++ b/asa_parser/src/asa_parse.py
@@ -111,17 +111,20 @@ class AsaParser(ShowTech):
         memory_region = []
         info = ''
 
-        for line in self.get_show_section('show_memory_region'):
-            if ' ASLR ' in line:
+        for line in self.get_show_section('memory region'):
+            if 'ASLR ' in line:
                 info = line
                 memory_region.append(info)
-            else:
-                data = line.split()
+            # only parse lines that are not blank
+            elif len(line):
+                print(line)
+                data = re.split(r'\s+', line)
                 mem = {'Address': data[0],
                        'Perm': data[1],
                        'Offset': data[2],
                        'Dev': data[3],
-                       'Inode': data[4]}
+                       'Inode': data[4],
+                       'Pathname': data[5]}
                 memory_region.append(mem)
         return json.dumps(memory_region)
 

--- a/asa_parser/tests/test_parser.py
+++ b/asa_parser/tests/test_parser.py
@@ -120,6 +120,7 @@ class ParserTest(unittest.TestCase):
         self.assertIn('"Offset"', result)
         self.assertIn('"Dev"', result)
         self.assertIn('"Inode"', result)
+        self.assertIn('"Pathname"', result)
         self.assertIn('["ASLR enabled, text region fff2b5c000-fff70be33c"', result)
 
     def test_cpu_detailed(self):

--- a/asa_parser/tests/test_parser.py
+++ b/asa_parser/tests/test_parser.py
@@ -114,13 +114,12 @@ class ParserTest(unittest.TestCase):
     def test_memory_region(self):
         asa = ap.AsaParser(os.path.join(self.txt_path, 'show_memory_region.txt'))
         result = asa.show_memory_region()
-        #self.assertIn('"info"', result)
-        #self.assertIn('"Address":', result)
-        #self.assertIn('"Address"', result)
-        #self.assertIn('"Perm"', result)
-        #self.assertIn('"Offset"', result)
-        #self.assertIn('"Dev"', result)
-        #self.assertIn('"Inode"', result)
+        self.assertIn('"Address":', result)
+        self.assertIn('"Address"', result)
+        self.assertIn('"Perm"', result)
+        self.assertIn('"Offset"', result)
+        self.assertIn('"Dev"', result)
+        self.assertIn('"Inode"', result)
         self.assertIn('["ASLR enabled, text region fff2b5c000-fff70be33c"', result)
 
     def test_cpu_detailed(self):

--- a/asa_parser/tests/test_parser.py
+++ b/asa_parser/tests/test_parser.py
@@ -114,7 +114,13 @@ class ParserTest(unittest.TestCase):
     def test_memory_region(self):
         asa = ap.AsaParser(os.path.join(self.txt_path, 'show_memory_region.txt'))
         result = asa.show_memory_region()
-        self.assertIn('"text":', result)
+        #self.assertIn('"info"', result)
+        #self.assertIn('"Address":', result)
+        #self.assertIn('"Address"', result)
+        #self.assertIn('"Perm"', result)
+        #self.assertIn('"Offset"', result)
+        #self.assertIn('"Dev"', result)
+        #self.assertIn('"Inode"', result)
         self.assertIn('["ASLR enabled, text region fff2b5c000-fff70be33c"', result)
 
     def test_cpu_detailed(self):


### PR DESCRIPTION
(base) Shaylas-MacBook-Pro:comp410_fall_2020 shayla$ pytest --cov=asa_parser
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.8.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /Users/shayla/Documents/SoftwareEngineering/Cisco/comp410_fall_2020
plugins: cov-2.10.1
collected 17 items                                                                                                                                         

asa_parser/tests/test_parser.py .................                                                                                                    [100%]

---------- coverage: platform darwin, python 3.8.3-final-0 -----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
asa_parser/__init__.py                2      0   100%
asa_parser/src/asa_parse.py          83      3    96%
asa_parser/src/shtech_parse.py       27      1    96%
asa_parser/tests/__init__.py          0      0   100%
asa_parser/tests/test_parser.py      97      0   100%
-----------------------------------------------------
TOTAL                               209      4    98%


==================================================================== 17 passed in 0.24s ====================================================================
<img width="754" alt="Screen Shot 2020-11-14 at 7 45 19 PM" src="https://user-images.githubusercontent.com/44929204/99160899-efd96200-26b1-11eb-928f-c0024b0c3596.png">
